### PR TITLE
Change the concourse version to 6.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM base AS test
 
 FROM alpine AS concourse-release
 
-	ARG CONCOURSE_VERSION=5.4.0
+	ARG CONCOURSE_VERSION=6.2.0
 
 	ADD https://github.com/concourse/concourse/releases/download/v${CONCOURSE_VERSION}/concourse-${CONCOURSE_VERSION}-linux-amd64.tgz /tmp
 	RUN tar xvzf /tmp/concourse-${CONCOURSE_VERSION}-linux-amd64.tgz -C /usr/local


### PR DESCRIPTION
```
"timestamp":"1591750163.118173838","source":"slirunner","message":"slirunner.run.login.finish","log_level":2,"data":{"error":"command execution failed: exit status 1","session":"1.220"}}
{"timestamp":"1591750343.022146225","source":"slirunner","message":"slirunner.run.login.start","log_level":1,"data":{"session":"1.221"}}
COMMAND FAILURE---
logging in to team 'main'

WARNING:

fly version (5.4.0) is out of sync with the target (6.2.0). to sync up, run the following:

    fly -t ci sync

error: oauth2: cannot fetch token: 404 Not Found
Response: 404 page not found
```