### PR TITLE
change concourse version 6.4.0 to fix error: user [] is not in team

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM base AS test
 
 FROM alpine AS concourse-release
 
-	ARG CONCOURSE_VERSION=6.2.0
+	ARG CONCOURSE_VERSION=6.4.0
 
 	ADD https://github.com/concourse/concourse/releases/download/v${CONCOURSE_VERSION}/concourse-${CONCOURSE_VERSION}-linux-amd64.tgz /tmp
 	RUN tar xvzf /tmp/concourse-${CONCOURSE_VERSION}-linux-amd64.tgz -C /usr/local

--- a/probes/pipeline_contents.go
+++ b/probes/pipeline_contents.go
@@ -33,7 +33,8 @@ jobs:
         type: registry-image
         source: {repository: busybox}
       run:
-        path: false
+        path: sh
+        args: ["-c", "exit 1"]
 
 - name: auto-triggering
   build_logs_to_retain: 20


### PR DESCRIPTION
with 6.4 path: false is not working.
```
run:	  
  path: false
```
error: error unmarshaling JSON: while decoding JSON: malformed task step: json: cannot unmarshal bool into Go struct field TaskRunConfig.config.run.path of type string